### PR TITLE
Verify code signature from catalog files

### DIFF
--- a/src/helper.h
+++ b/src/helper.h
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2021 Henry++
 
 #pragma once
-
+#include <mscat.h>
 #define FMTADDR_AS_ARPA 0x0001
 #define FMTADDR_AS_RULE 0x0002
 #define FMTADDR_USE_PROTOCOL 0x0004


### PR DESCRIPTION
Hello,
Most of Windows executable are signed in .cab files.
This commit add a check to handle this common case.

![image](https://user-images.githubusercontent.com/14371201/131223861-92d8f331-7bed-4e20-980f-5bb1c366cbef.png)


Regards,