### PR TITLE
Allow importing profiles from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To remove all filters created by simplewall, start simplewall and press "Disable
 -install -temp - enable filtering until next reboot.
 -install -silent - enable filtering without prompt.
 -uninstall - remove all installed filters.
+-import <path> - import profile from specified path.
 ~~~
 
 ### Rules editor:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To remove all filters created by simplewall, start simplewall and press "Disable
 -install -temp - enable filtering until next reboot.
 -install -silent - enable filtering without prompt.
 -uninstall - remove all installed filters.
--import <path> - import profile from specified path.
+-install -import <path> - enable filtering and import profile from specified path.
 ~~~
 
 ### Rules editor:

--- a/src/main.c
+++ b/src/main.c
@@ -3897,8 +3897,19 @@ BOOLEAN NTAPI _app_parseargs (
 				if (_r_sys_getopt (_r_sys_getcommandline (), L"temp", NULL))
 					config.is_filterstemporary = TRUE;
 
+				PR_STRING import_path = _r_sys_getopt (_r_sys_getcommandline (), L"import", NULL);
+
 				_app_profile_initialize ();
-				_app_profile_load (NULL, NULL);
+
+				if (import_path)
+				{
+					_app_profile_load (NULL, import_path);
+					_r_obj_dereference (import_path);
+				}
+				else
+				{
+					_app_profile_load (NULL, NULL);
+				}
 
 				if (_wfp_initialize (NULL, hengine))
 					_wfp_installfilters (hengine);

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,3 @@
-// simplewall
-// Copyright (c) 2016-2024 Henry++
-
 #include "global.h"
 
 BOOLEAN _app_changefilters (
@@ -3886,6 +3883,7 @@ BOOLEAN NTAPI _app_parseargs (
 				L"simplewall.exe -install -temp - enable filtering until reboot.\r\n"
 				L"simplewall.exe -install -silent - enable filtering without prompt.\r\n"
 				L"simplewall.exe -uninstall - remove all installed filters.\r\n"
+				L"simplewall.exe -import <path> - import profile from specified path.\r\n"
 				L"simplewall.exe -help - show this message."
 			);
 
@@ -3917,6 +3915,29 @@ BOOLEAN NTAPI _app_parseargs (
 			{
 				_wfp_destroyfilters (hengine);
 				_wfp_uninitialize (hengine, TRUE);
+			}
+
+			return TRUE;
+		}
+
+		case CmdlineImport:
+		{
+			PR_STRING path;
+			NTSTATUS status;
+
+			path = _r_sys_getopt (_r_sys_getcommandline (), L"import", NULL);
+
+			if (path)
+			{
+				status = _app_profile_load (NULL, path);
+
+				if (NT_SUCCESS (status))
+				{
+					_app_profile_save (NULL);
+					_app_changefilters (NULL, TRUE, FALSE);
+				}
+
+				_r_obj_dereference (path);
 			}
 
 			return TRUE;


### PR DESCRIPTION
Fixes #1921

I generated this PR using Copilot Workspace. It adds a separate -import flag. However, I think it might be better to make the -import flag an optional flag that works with -install (similar to how -temp and -silent currently works). If given, `_app_profile_load` should be called with the file path instead of `NULL` (if I understood the code correctly).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/henrypp/simplewall/pull/1935?shareId=f6be893b-3c57-4ac7-a9ff-d8a27e042bf0).